### PR TITLE
External TailwindCSS with custom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,12 @@ The following plugin options may be configured:
 ### stencil.config.ts
 
 ```js
+import tailwindcss from 'tailwindcss'
+
 export const config: Config = {
   plugins: [
     tailwind({
+      tailwind: tailwindcss('tailwind.config.js'),
       inputFile: './src/styles/app.css',
       includeTailwindCss: false
     })
@@ -135,5 +138,6 @@ export const config: Config = {
 }
 ```
 
+* `tailwind`: **(optional)** your own configuration file and version of TailwindCSS to be used. 
 * `inputFile`: **(optional)** a stylesheet filepath to be used in place of the default.
 * `includeTailwindCss`: **(optional)** include global `tailwind.css` in the bundle (default: `true`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export default function tailwind(opts?: PluginOptions): Plugin {
     async buildStart() {
       debug.time('build start')
       return readFile(options.inputFile!).then(async css =>
-        postcss([ tailwindcss() ])
+        postcss([ options.tailwind! ])
           .process(css, { from: options.inputFile })
           .then(async result => {
             debug.time('style tree built')
@@ -52,6 +52,7 @@ export default function tailwind(opts?: PluginOptions): Plugin {
 
 function _buildOptions(opts?: PluginOptions): PluginOptions {
   const defaults: PluginOptions = {
+    tailwind: tailwindcss(),
     inputFile: path.join(__dirname, '/app.css'),
     includeTailwindCss: true
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export default function tailwind(opts?: PluginOptions): Plugin {
 
     async buildStart() {
       debug.time('build start')
-      return readFile(options.inputFile).then(async css =>
+      return readFile(options.inputFile!).then(async css =>
         postcss([ tailwindcss() ])
           .process(css, { from: options.inputFile })
           .then(async result => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,8 +2,8 @@ export { Plugin } from 'rollup'
 
 export interface PluginOptions {
 
-  inputFile: string,
-  includeTailwindCss: boolean
+  inputFile?: string,
+  includeTailwindCss?: boolean
 
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,10 @@
+import postcss from 'postcss';
+
 export { Plugin } from 'rollup'
 
 export interface PluginOptions {
 
+  tailwind?: postcss.AcceptedPlugin;
   inputFile?: string,
   includeTailwindCss?: boolean
 


### PR DESCRIPTION
First of all, thanks for a great library! To actually use it in production it is important for me to bring my own TailwindCSS with a custom configuration file, I hope this is useful for others too.

This PR adds two things:
* a possibility to use your own TailwindCSS dependency and custom configuration file
* makes plugin options really optional. Now if you want to specify one, Typescript complains to specify the other too. 